### PR TITLE
Display git SHA on the index page instead of a timestamp.

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -41,7 +41,7 @@ action "Login into Docker Hub" {
 action "Build a Docker container" {
   uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
   needs = ["If master branch"]
-  args = "build -t base ."
+  args = "build -t base --build-arg GITHUB_SHA_ARG=$GITHUB_SHA ."
 }
 
 action "Tag :latest" {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 LABEL maintainer="paul.craig@cds-snc.ca"
 
-ARG GITHUB_SHA_ARG=false
+ARG GITHUB_SHA_ARG
 ENV GITHUB_SHA=$GITHUB_SHA_ARG
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:lts-alpine
 LABEL maintainer="paul.craig@cds-snc.ca"
 
+ARG GITHUB_SHA_ARG=false
+ENV GITHUB_SHA=$GITHUB_SHA_ARG
+
 WORKDIR /app
 COPY . .
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  publicRuntimeConfig: {
+    githubSha: process.env.GITHUB_SHA || false,
+  },
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import getConfig from 'next/config'
 
-const { publicRuntimeConfig } = getConfig()
+const { publicRuntimeConfig: { githubSha = false } = {} } = getConfig() || {}
 
 const Index = () => (
   <div>
@@ -11,9 +11,7 @@ const Index = () => (
       <a>Page Two</a>
     </Link>
     <br />
-    {publicRuntimeConfig.githubSha ? (
-      <p>Last commit: {`${publicRuntimeConfig.githubSha}`}</p>
-    ) : null}
+    {githubSha ? <p>Last commit: {`${githubSha}`}</p> : null}
   </div>
 )
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,14 @@ const Index = () => (
       <a>Page Two</a>
     </Link>
     <br />
-    {githubSha ? <p>Last commit: {`${githubSha}`}</p> : null}
+    {githubSha ? (
+      <p>
+        Last commit:{' '}
+        <a
+          href={`https://github.com/cds-snc/az-next/commit/${githubSha}`}
+        >{`${githubSha}`}</a>
+      </p>
+    ) : null}
   </div>
 )
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,7 @@
 import Link from 'next/link'
+import getConfig from 'next/config'
+
+const { publicRuntimeConfig } = getConfig()
 
 const Index = () => (
   <div>
@@ -8,7 +11,9 @@ const Index = () => (
       <a>Page Two</a>
     </Link>
     <br />
-    <p>Last updated: Mon, 18 Mar 2019 22:30:00 GMT</p>
+    {publicRuntimeConfig.githubSha ? (
+      <p>Last commit: {`${publicRuntimeConfig.githubSha}`}</p>
+    ) : null}
   </div>
 )
 


### PR DESCRIPTION
This will mean that we can keep track of what build is actually running after its deployed.